### PR TITLE
Replace obsolete contructor invocations

### DIFF
--- a/SavePanel.uno
+++ b/SavePanel.uno
@@ -28,7 +28,7 @@ public class SavePanel : Fuse.Controls.Panel
         _instance = this;
 
 		ScriptClass.Register(typeof(SavePanel),
-			new ScriptMethod<SavePanel>("save", Save, ExecutionThread.MainThread));
+			new ScriptMethod<SavePanel>("save", Save));
 	}
 
 	public string GetPath()
@@ -36,7 +36,7 @@ public class SavePanel : Fuse.Controls.Panel
     	return imagePath;
     }
 
-	static void Save(Context c, SavePanel s, object [] args) {
+	static void Save(SavePanel s, object[] args) {
 		if (args.Length != 1)
 		{
 			Fuse.Diagnostics.UserError( "SavePanel.save requires 1 parameter (filename)", s );

--- a/Signature.uno
+++ b/Signature.uno
@@ -30,11 +30,11 @@ public class Signature : Fuse.Controls.Panel
         if(_valid)
         {
            ScriptClass.Register(typeof(Signature),
-            new ScriptMethod<Signature>("clear", ClearDrawing, ExecutionThread.MainThread));
+            new ScriptMethod<Signature>("clear", ClearDrawing));
         }
     }
 
-    public void ClearDrawing(Context c, Signature s, object[] args)
+    public void ClearDrawing(Signature s, object[] args)
     {
         ClearSignature = true;
     }


### PR DESCRIPTION
This makes our app build & run on latest Fuselibs.

The old `ScriptMethod<T>` constructor was removed in
https://github.com/fuse-open/fuselibs/pull/1389/files#diff-6dcbe5df54258a7e50e021cd3329ec4a396573035a193479fdc9a64a19e765fdL126